### PR TITLE
refactor: migrate to SecretsManager pattern

### DIFF
--- a/kling/griptape_nodes_library.json
+++ b/kling/griptape_nodes_library.json
@@ -3,11 +3,13 @@
     "library_schema_version": "0.1.0",
     "settings": [
         {
-            "description": "Environment variables for storing secrets for new AI service's nodes",
-            "category": "nodes.Kling",
+            "description": "API keys required by nodes in this library",
+            "category": "app_events.on_app_initialization_complete",
             "contents": {
-                "KLING_ACCESS_KEY": "$KLING_ACCESS_KEY",
-                "KLING_SECRET_KEY": "$KLING_SECRET_KEY"
+                "secrets_to_register": [
+                    "KLING_ACCESS_KEY",
+                    "KLING_SECRET_KEY"
+                ]
             }
         }
     ],

--- a/kling/image_to_video.py
+++ b/kling/image_to_video.py
@@ -246,8 +246,8 @@ class KlingAI_ImageToVideo(ControlNode):
 
     def validate_node(self) -> list[Exception] | None:
         errors = []
-        access_key = self.get_config_value(service=SERVICE, value=API_KEY_ENV_VAR)
-        secret_key = self.get_config_value(service=SERVICE, value=SECRET_KEY_ENV_VAR)
+        access_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
+        secret_key = GriptapeNodes.SecretsManager().get_secret(SECRET_KEY_ENV_VAR)
 
         if not access_key:
             errors.append(ValueError(f"Kling access key not found. Set {API_KEY_ENV_VAR}."))
@@ -308,8 +308,8 @@ class KlingAI_ImageToVideo(ControlNode):
             raise ValueError(f"Validation failed: {error_message}")
             
         def generate_video() -> VideoUrlArtifact:
-            access_key = self.get_config_value(service=SERVICE, value=API_KEY_ENV_VAR)
-            secret_key = self.get_config_value(service=SERVICE, value=SECRET_KEY_ENV_VAR)
+            access_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
+            secret_key = GriptapeNodes.SecretsManager().get_secret(SECRET_KEY_ENV_VAR)
             jwt_token = encode_jwt_token(access_key, secret_key) # type: ignore[arg-type]
             headers = {"Content-Type": "application/json", "Authorization": f"Bearer {jwt_token}"}
 

--- a/kling/lip_sync.py
+++ b/kling/lip_sync.py
@@ -266,8 +266,8 @@ class KlingAI_LipSync(ControlNode):
     def validate_node(self) -> list[Exception] | None:
         """Validates that the Kling API keys are configured and parameters are valid."""
         errors = []
-        access_key = self.get_config_value(service=SERVICE, value=API_KEY_ENV_VAR)
-        secret_key = self.get_config_value(service=SERVICE, value=SECRET_KEY_ENV_VAR)
+        access_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
+        secret_key = GriptapeNodes.SecretsManager().get_secret(SECRET_KEY_ENV_VAR)
 
         if not access_key:
             errors.append(ValueError(f"Kling access key not found. Set {API_KEY_ENV_VAR}."))
@@ -368,8 +368,8 @@ class KlingAI_LipSync(ControlNode):
             raise ValueError(f"Validation failed: {error_message}")
             
         def create_lip_sync() -> VideoUrlArtifact:
-            access_key = self.get_config_value(service=SERVICE, value=API_KEY_ENV_VAR)
-            secret_key = self.get_config_value(service=SERVICE, value=SECRET_KEY_ENV_VAR)
+            access_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
+            secret_key = GriptapeNodes.SecretsManager().get_secret(SECRET_KEY_ENV_VAR)
             jwt_token = encode_jwt_token(access_key, secret_key)
             headers = {"Content-Type": "application/json", "Authorization": f"Bearer {jwt_token}"}
 

--- a/kling/text_to_video.py
+++ b/kling/text_to_video.py
@@ -165,8 +165,8 @@ class KlingAI_TextToVideo(ControlNode):
         Returns:
             list[Exception] | None: List of exceptions if validation fails, None if validation passes.
         """
-        access_key = self.get_config_value(service=SERVICE, value=API_KEY_ENV_VAR)
-        secret_key = self.get_config_value(service=SERVICE, value=SECRET_KEY_ENV_VAR)
+        access_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
+        secret_key = GriptapeNodes.SecretsManager().get_secret(SECRET_KEY_ENV_VAR)
 
         errors = []
         if not access_key:
@@ -203,8 +203,8 @@ class KlingAI_TextToVideo(ControlNode):
         prompt = self.get_parameter_value("prompt")
 
         def generate_video() -> VideoUrlArtifact:
-            access_key = self.get_config_value(service=SERVICE, value=API_KEY_ENV_VAR)
-            secret_key = self.get_config_value(service=SERVICE, value=SECRET_KEY_ENV_VAR)
+            access_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
+            secret_key = GriptapeNodes.SecretsManager().get_secret(SECRET_KEY_ENV_VAR)
 
             jwt_token = encode_jwt_token(access_key, secret_key)
 

--- a/kling/video_extension.py
+++ b/kling/video_extension.py
@@ -127,8 +127,8 @@ class KlingAI_VideoExtension(ControlNode):
     def validate_node(self) -> list[Exception] | None:
         """Validates that the Kling API keys are configured and parameters are valid."""
         errors = []
-        access_key = self.get_config_value(service=SERVICE, value=API_KEY_ENV_VAR)
-        secret_key = self.get_config_value(service=SERVICE, value=SECRET_KEY_ENV_VAR)
+        access_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
+        secret_key = GriptapeNodes.SecretsManager().get_secret(SECRET_KEY_ENV_VAR)
 
         if not access_key:
             errors.append(ValueError(f"Kling access key not found. Set {API_KEY_ENV_VAR}."))
@@ -155,8 +155,8 @@ class KlingAI_VideoExtension(ControlNode):
             raise ValueError(f"Validation failed: {error_message}")
             
         def extend_video() -> VideoUrlArtifact:
-            access_key = self.get_config_value(service=SERVICE, value=API_KEY_ENV_VAR)
-            secret_key = self.get_config_value(service=SERVICE, value=SECRET_KEY_ENV_VAR)
+            access_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
+            secret_key = GriptapeNodes.SecretsManager().get_secret(SECRET_KEY_ENV_VAR)
             jwt_token = encode_jwt_token(access_key, secret_key)
             headers = {"Content-Type": "application/json", "Authorization": f"Bearer {jwt_token}"}
 


### PR DESCRIPTION
- Updated all 4 Kling nodes to use GriptapeNodes.SecretsManager().get_secret()
- Replaced get_config_value(service=SERVICE, value=API_KEY_ENV_VAR) pattern
- Affected nodes: text_to_video, image_to_video, video_extension, lip_sync
- Updated both validate_node() and process() methods in each node
- Updated griptape_nodes_library.json to use secrets_to_register array
- Changed category to app_events.on_app_initialization_complete
- Maintains backwards compatibility with same error messages
- GriptapeNodes already imported at module level in all files