### PR TITLE
fix: add kling-v2-6 to end frame validation

### DIFF
--- a/kling/image_to_video.py
+++ b/kling/image_to_video.py
@@ -316,7 +316,8 @@ class KlingAI_ImageToVideo(ControlNode):
         if image_tail_val:
             end_frame_supported = (
                 (model == "kling-v2-1" and mode == "pro" and duration in [5, 10]) or
-                (model == "kling-v2-5-turbo" and mode == "pro" and duration in [5, 10])
+                (model == "kling-v2-5-turbo" and mode == "pro" and duration in [5, 10]) or
+                (model == "kling-v2-6" and mode == "pro" and duration in [5, 10])
             )
             if not end_frame_supported:
                 errors.append(


### PR DESCRIPTION
## Summary
- Add support for kling-v2-6 model in the end_frame_supported validation check
- Allows image tail input for kling-v2-6 model in pro mode with 5 or 10 second durations

## Test plan
- [ ] Test image-to-video generation with kling-v2-6 model using end frame image
- [ ] Verify validation correctly allows image_tail for pro mode with 5s and 10s durations
- [ ] Confirm validation still rejects unsupported configurations