### PR TITLE
feat(kling): add kling-v3 model choice to image/text video

### DIFF
--- a/kling/image_to_video.py
+++ b/kling/image_to_video.py
@@ -57,6 +57,7 @@ class KlingAI_ImageToVideo(ControlNode):
                             "kling-v2-1-master",
                             "kling-v2-5-turbo",
                             "kling-v2-6",
+                            "kling-v3"
                         ]
                     )
                 },

--- a/kling/text_to_video.py
+++ b/kling/text_to_video.py
@@ -57,7 +57,7 @@ class KlingAI_TextToVideo(ControlNode):
                 default_value="kling-v1-6",
                 tooltip="Model Name",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=["kling-v1-6", "kling-v2-master", "kling-v2-1-master", "kling-v2-5-turbo", "kling-v2-6"])}
+                traits={Options(choices=["kling-v1-6", "kling-v2-master", "kling-v2-1-master", "kling-v2-5-turbo", "kling-v2-6", "kling-v3"])}
             )
         )
         self.add_parameter(


### PR DESCRIPTION
## Summary
- Add 'kling-v3' to allowed model options in both `kling/image_to_video.py` and `kling/text_to_video.py`.
- Enables selecting the latest Kling model in image-to-video and text-to-video nodes.

## Context
No behavioral changes beyond exposing the new model identifier in the options list.

## Test Plan
- Open both nodes and verify `kling-v3` appears in the Model Name options.
- Run a short generation using `kling-v3` to confirm end-to-end selection works.

## Notes
No docs or config changes required.

Made with [Cursor](https://cursor.com)