### PR TITLE
feat: Kling v3 Multi-Shot video generation node

### DIFF
--- a/kling/griptape_nodes_library.json
+++ b/kling/griptape_nodes_library.json
@@ -101,7 +101,7 @@
             "file_path": "kling_v3_multi_shot.py",
             "metadata": {
                 "category": "video/kling ai",
-                "description": "Kling v3 multi-shot video node with custom shot editor",
+                "description": "Generates multi-shot videos using Kling v3 with per-shot prompts and durations.",
                 "display_name": "Kling v3 Multi-Shot"
             }
         }

--- a/kling/griptape_nodes_library.json
+++ b/kling/griptape_nodes_library.json
@@ -33,6 +33,13 @@
             ]
         }
     },
+    "widgets": [
+        {
+            "name": "MultiShotEditor",
+            "path": "widgets/MultiShotEditor.js",
+            "description": "Multi-shot editor for managing video shot sequences"
+        }
+    ],
     "categories": [
         {
             "video/kling ai": {
@@ -87,6 +94,15 @@
                 "category": "video/kling ai",
                 "description": "Transfers motion from a reference video to a reference image using Kling Motion Control.",
                 "display_name": "Kling Motion Control"
+            }
+        },
+        {
+            "class_name": "KlingV3MultiShot",
+            "file_path": "kling_v3_multi_shot.py",
+            "metadata": {
+                "category": "video/kling ai",
+                "description": "Kling v3 multi-shot video node with custom shot editor",
+                "display_name": "Kling v3 Multi-Shot"
             }
         }
     ]

--- a/kling/kling_v3_multi_shot.py
+++ b/kling/kling_v3_multi_shot.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import DataNode
+from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
 from griptape_nodes.traits.widget import Widget
 
 
@@ -20,22 +21,18 @@ class KlingV3MultiShot(DataNode):
         super().__init__(name=name, metadata=node_metadata, **kwargs)
 
         self.add_parameter(
-            Parameter(
+            ParameterImage(
                 name="start_frame",
-                input_types=["ImageArtifact", "ImageUrlArtifact"],
-                type="ImageArtifact",
                 tooltip="Starting frame for the video sequence",
-                allowed_modes={ParameterMode.INPUT},
+                allow_output=False,
             )
         )
 
         self.add_parameter(
-            Parameter(
+            ParameterImage(
                 name="end_frame",
-                input_types=["ImageArtifact", "ImageUrlArtifact"],
-                type="ImageArtifact",
                 tooltip="Ending frame for the video sequence",
-                allowed_modes={ParameterMode.INPUT},
+                allow_output=False,
             )
         )
 

--- a/kling/kling_v3_multi_shot.py
+++ b/kling/kling_v3_multi_shot.py
@@ -1,0 +1,68 @@
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import DataNode
+from griptape_nodes.traits.widget import Widget
+
+
+class KlingV3MultiShot(DataNode):
+    """Multi-shot video node with a custom shot list editor for sequencing video shots."""
+
+    DEFAULT_SHOTS = [{"name": "Shot1", "duration": 2, "description": ""}]
+
+    def __init__(self, name: str, metadata: dict[str, Any] | None = None, **kwargs) -> None:
+        node_metadata = {
+            "category": "video/kling ai",
+            "description": "Kling v3 multi-shot video node with custom shot editor",
+        }
+        if metadata:
+            node_metadata.update(metadata)
+        super().__init__(name=name, metadata=node_metadata, **kwargs)
+
+        self.add_parameter(
+            Parameter(
+                name="start_frame",
+                input_types=["VideoUrlArtifact"],
+                type="VideoUrlArtifact",
+                tooltip="Starting frame for the video sequence",
+                allowed_modes={ParameterMode.INPUT},
+            )
+        )
+
+        self.add_parameter(
+            Parameter(
+                name="end_frame",
+                input_types=["VideoUrlArtifact"],
+                type="VideoUrlArtifact",
+                tooltip="Ending frame for the video sequence",
+                allowed_modes={ParameterMode.INPUT},
+            )
+        )
+
+        self.add_parameter(
+            Parameter(
+                name="shots",
+                input_types=["list"],
+                type="list",
+                output_type="list",
+                default_value=self.DEFAULT_SHOTS,
+                tooltip="List of shots with name, duration, and description",
+                allowed_modes={ParameterMode.PROPERTY, ParameterMode.OUTPUT},
+                traits={Widget(name="MultiShotEditor", library="Kling AI Library")},
+            )
+        )
+
+    def process(self) -> None:
+        start_frame = self.parameter_values.get("start_frame")
+        end_frame = self.parameter_values.get("end_frame")
+        shots = self.parameter_values.get("shots", self.DEFAULT_SHOTS)
+
+        total_duration = sum(shot.get("duration", 2) for shot in shots)
+        print(
+            f"KlingV3MultiShot - {len(shots)} shots, "
+            f"total duration: {total_duration}s, "
+            f"start_frame: {'set' if start_frame else 'none'}, "
+            f"end_frame: {'set' if end_frame else 'none'}"
+        )
+
+        self.parameter_output_values["shots"] = shots

--- a/kling/kling_v3_multi_shot.py
+++ b/kling/kling_v3_multi_shot.py
@@ -22,8 +22,8 @@ class KlingV3MultiShot(DataNode):
         self.add_parameter(
             Parameter(
                 name="start_frame",
-                input_types=["VideoUrlArtifact"],
-                type="VideoUrlArtifact",
+                input_types=["ImageArtifact", "ImageUrlArtifact"],
+                type="ImageArtifact",
                 tooltip="Starting frame for the video sequence",
                 allowed_modes={ParameterMode.INPUT},
             )
@@ -32,8 +32,8 @@ class KlingV3MultiShot(DataNode):
         self.add_parameter(
             Parameter(
                 name="end_frame",
-                input_types=["VideoUrlArtifact"],
-                type="VideoUrlArtifact",
+                input_types=["ImageArtifact", "ImageUrlArtifact"],
+                type="ImageArtifact",
                 tooltip="Ending frame for the video sequence",
                 allowed_modes={ParameterMode.INPUT},
             )

--- a/kling/kling_v3_multi_shot.py
+++ b/kling/kling_v3_multi_shot.py
@@ -252,14 +252,14 @@ class KlingV3MultiShot(ControlNode):
         # Build multi_prompt from shots
         shots = self.parameter_values.get("shots", self.DEFAULT_SHOTS)
         multi_prompt = []
-        for shot in shots:
+        for i, shot in enumerate(shots):
             description = shot.get("description", "").strip()
             duration = shot.get("duration", 2)
-            # Append duration to each prompt so the API can allocate time per shot
-            if description:
-                multi_prompt.append(f"{description}, {duration} seconds")
-            else:
-                multi_prompt.append(f"{duration} seconds")
+            multi_prompt.append({
+                "index": i,
+                "prompt": description,
+                "duration": str(duration),
+            })
 
         total_duration = sum(shot.get("duration", 1) for shot in shots)
 

--- a/kling/kling_v3_multi_shot.py
+++ b/kling/kling_v3_multi_shot.py
@@ -1,41 +1,71 @@
+import base64
+import json
+import time
 from typing import Any
 
-from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
-from griptape_nodes.exe_types.node_types import DataNode
-from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
+import jwt
+import requests
+from griptape.artifacts import ImageArtifact, ImageUrlArtifact, VideoUrlArtifact
+from griptape_nodes.traits.options import Options
+from griptape_nodes.traits.slider import Slider
 from griptape_nodes.traits.widget import Widget
 
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, ParameterGroup
+from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
+from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
+from griptape_nodes.retained_mode.griptape_nodes import logger, GriptapeNodes
+from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 
-class KlingV3MultiShot(DataNode):
-    """Multi-shot video node with a custom shot list editor for sequencing video shots."""
+SERVICE = "Kling"
+API_KEY_ENV_VAR = "KLING_ACCESS_KEY"
+SECRET_KEY_ENV_VAR = "KLING_SECRET_KEY"  # noqa: S105
+BASE_URL = "https://api.klingai.com/v1/videos/image2video"
 
-    DEFAULT_SHOTS = [{"name": "Shot1", "duration": 2, "description": ""}]
+
+def encode_jwt_token(ak: str, sk: str) -> str:
+    headers = {"alg": "HS256", "typ": "JWT"}
+    payload = {
+        "iss": ak,
+        "exp": int(time.time()) + 1800,
+        "nbf": int(time.time()) - 5,
+    }
+    token = jwt.encode(payload, sk, algorithm="HS256", headers=headers)
+    return token
+
+
+class KlingV3MultiShot(ControlNode):
+    """Multi-shot video node for Kling v3 with a custom shot list editor.
+
+    Uses the multi_prompt API parameter to generate multi-shot video sequences
+    where each shot has its own prompt and duration.
+    """
+
+    DEFAULT_SHOTS = [{"name": "Shot1", "duration": 3, "description": ""}]
 
     def __init__(self, name: str, metadata: dict[str, Any] | None = None, **kwargs) -> None:
         node_metadata = {
             "category": "video/kling ai",
-            "description": "Kling v3 multi-shot video node with custom shot editor",
+            "description": "Kling v3 multi-shot video generation with per-shot prompts and durations",
         }
         if metadata:
             node_metadata.update(metadata)
         super().__init__(name=name, metadata=node_metadata, **kwargs)
 
-        self.add_parameter(
+        # Image Inputs
+        with ParameterGroup(name="Image Inputs") as image_group:
             ParameterImage(
                 name="start_frame",
-                tooltip="Starting frame for the video sequence",
+                tooltip="Starting frame image for the video sequence (required)",
                 allow_output=False,
             )
-        )
-
-        self.add_parameter(
             ParameterImage(
                 name="end_frame",
-                tooltip="Ending frame for the video sequence",
+                tooltip="Ending frame image (optional, not compatible with multi-prompt on some API versions)",
                 allow_output=False,
             )
-        )
+        self.add_node_element(image_group)
 
+        # Shot List (custom widget)
         self.add_parameter(
             Parameter(
                 name="shots",
@@ -49,17 +79,290 @@ class KlingV3MultiShot(DataNode):
             )
         )
 
-    def process(self) -> None:
-        start_frame = self.parameter_values.get("start_frame")
-        end_frame = self.parameter_values.get("end_frame")
-        shots = self.parameter_values.get("shots", self.DEFAULT_SHOTS)
+        # Generation Settings
+        with ParameterGroup(name="Generation Settings") as gen_settings_group:
+            Parameter(
+                name="cfg_scale",
+                input_types=["float"],
+                output_type="float",
+                type="float",
+                default_value=0.5,
+                tooltip="Flexibility (0-1). Higher value = lower flexibility, stronger prompt relevance.",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+            Parameter(
+                name="mode",
+                input_types=["str"],
+                output_type="str",
+                type="str",
+                default_value="std",
+                tooltip="Video generation mode (std: Standard, pro: Professional)",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                traits={Options(choices=["std", "pro"])},
+            )
+            Parameter(
+                name="aspect_ratio",
+                input_types=["str"],
+                output_type="str",
+                type="str",
+                default_value="16:9",
+                tooltip="Aspect ratio of the generated video",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                traits={Options(choices=["16:9", "9:16", "1:1"])},
+            )
+            Parameter(
+                name="negative_prompt",
+                input_types=["str"],
+                output_type="str",
+                type="str",
+                default_value="",
+                tooltip="Negative text prompt — elements to avoid (max 2500 chars)",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                ui_options={"multiline": True},
+            )
+            Parameter(
+                name="sound",
+                input_types=["str"],
+                output_type="str",
+                type="str",
+                default_value="off",
+                tooltip="Generate native audio with the video",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                traits={Options(choices=["on", "off"])},
+            )
+            Parameter(
+                name="polling_delay",
+                input_types=["int"],
+                output_type="int",
+                type="int",
+                default_value=10,
+                tooltip="Delay in seconds between polling the Kling API for job completion.",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                traits={Slider(min_val=5, max_val=30)},
+                hide=True,
+            )
+        self.add_node_element(gen_settings_group)
 
-        total_duration = sum(shot.get("duration", 2) for shot in shots)
-        print(
-            f"KlingV3MultiShot - {len(shots)} shots, "
-            f"total duration: {total_duration}s, "
-            f"start_frame: {'set' if start_frame else 'none'}, "
-            f"end_frame: {'set' if end_frame else 'none'}"
+        # Output
+        self.add_parameter(
+            Parameter(
+                name="video_url",
+                output_type="VideoUrlArtifact",
+                type="VideoUrlArtifact",
+                default_value=None,
+                allowed_modes={ParameterMode.OUTPUT},
+                tooltip="Output URL of the generated multi-shot video.",
+                ui_options={"placeholder_text": "", "is_full_width": True},
+            )
         )
 
-        self.parameter_output_values["shots"] = shots
+    def _get_image_api_data(self, param_name: str) -> str | None:
+        """Convert an image parameter to API-compatible format (URL or base64)."""
+        image_input = self.parameter_values.get(param_name)
+        if image_input is None:
+            return None
+
+        if isinstance(image_input, ImageUrlArtifact):
+            return self._resolve_url(image_input.value)
+        if isinstance(image_input, ImageArtifact):
+            return image_input.base64
+        if isinstance(image_input, dict):
+            input_type = image_input.get("type")
+            if input_type == "ImageUrlArtifact" and image_input.get("value"):
+                return self._resolve_url(str(image_input["value"]))
+            if input_type == "ImageArtifact" and image_input.get("base64"):
+                return str(image_input["base64"])
+            return None
+        if isinstance(image_input, str) and image_input.strip():
+            return self._resolve_url(image_input.strip())
+
+        return None
+
+    def _resolve_url(self, url_string: str) -> str:
+        """Convert local URLs to base64, pass public URLs through."""
+        if not url_string:
+            return url_string
+
+        if url_string.startswith("data:image"):
+            try:
+                return url_string.split(",", 1)[1]
+            except Exception:
+                return url_string
+
+        is_local = "localhost" in url_string or "127.0.0.1" in url_string
+        if is_local and url_string.startswith("http"):
+            try:
+                response = requests.get(url_string, timeout=10)
+                response.raise_for_status()
+                return base64.b64encode(response.content).decode("utf-8")
+            except requests.exceptions.RequestException as e:
+                logger.error(f"Failed to fetch local URL for base64 conversion: {e}")
+                return url_string
+
+        return url_string
+
+    def validate_node(self) -> list[Exception] | None:
+        errors = []
+
+        access_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
+        secret_key = GriptapeNodes.SecretsManager().get_secret(SECRET_KEY_ENV_VAR)
+        if not access_key:
+            errors.append(ValueError(f"Kling access key not found. Set {API_KEY_ENV_VAR}."))
+        if not secret_key:
+            errors.append(ValueError(f"Kling secret key not found. Set {SECRET_KEY_ENV_VAR}."))
+
+        image_api = self._get_image_api_data("start_frame")
+        if not image_api:
+            errors.append(ValueError("start_frame image is required."))
+
+        shots = self.parameter_values.get("shots", self.DEFAULT_SHOTS)
+        if not shots:
+            errors.append(ValueError("At least one shot is required."))
+        else:
+            total_duration = sum(shot.get("duration", 1) for shot in shots)
+            if total_duration < 3:
+                errors.append(ValueError(f"Total duration must be at least 3 seconds (currently {total_duration}s)."))
+            if total_duration > 15:
+                errors.append(ValueError(f"Total duration cannot exceed 15 seconds (currently {total_duration}s)."))
+
+            has_any_description = any(shot.get("description", "").strip() for shot in shots)
+            if not has_any_description:
+                errors.append(ValueError("At least one shot must have a description."))
+
+        cfg_scale = self.parameter_values.get("cfg_scale", 0.5)
+        if not (0 <= cfg_scale <= 1):
+            errors.append(ValueError("cfg_scale must be between 0.0 and 1.0."))
+
+        return errors if errors else None
+
+    def process(self) -> AsyncResult[None]:
+        yield lambda: self._process()
+
+    def _process(self):
+        validation_errors = self.validate_node()
+        if validation_errors:
+            error_message = "; ".join(str(e) for e in validation_errors)
+            raise ValueError(f"Validation failed: {error_message}")
+
+        access_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
+        secret_key = GriptapeNodes.SecretsManager().get_secret(SECRET_KEY_ENV_VAR)
+        jwt_token = encode_jwt_token(access_key, secret_key)
+        headers = {"Content-Type": "application/json", "Authorization": f"Bearer {jwt_token}"}
+
+        # Build multi_prompt from shots
+        shots = self.parameter_values.get("shots", self.DEFAULT_SHOTS)
+        multi_prompt = []
+        for shot in shots:
+            description = shot.get("description", "").strip()
+            duration = shot.get("duration", 2)
+            # Append duration to each prompt so the API can allocate time per shot
+            if description:
+                multi_prompt.append(f"{description}, {duration} seconds")
+            else:
+                multi_prompt.append(f"{duration} seconds")
+
+        total_duration = sum(shot.get("duration", 1) for shot in shots)
+
+        # Build payload
+        payload: dict[str, Any] = {
+            "model_name": "kling-v3",
+            "multi_prompt": multi_prompt,
+            "duration": total_duration,
+            "cfg_scale": self.parameter_values.get("cfg_scale", 0.5),
+            "mode": self.parameter_values.get("mode", "std"),
+        }
+
+        # Image inputs
+        image_api = self._get_image_api_data("start_frame")
+        if image_api:
+            payload["image"] = image_api
+
+        image_tail_api = self._get_image_api_data("end_frame")
+        if image_tail_api:
+            payload["image_tail"] = image_tail_api
+
+        # Optional parameters
+        neg_prompt = self.parameter_values.get("negative_prompt", "")
+        if neg_prompt and neg_prompt.strip():
+            payload["negative_prompt"] = neg_prompt.strip()
+
+        sound_val = self.parameter_values.get("sound", "off")
+        if sound_val:
+            payload["sound"] = sound_val
+
+        # Log payload (redact base64 data)
+        log_payload = payload.copy()
+        for key in ["image", "image_tail"]:
+            if key in log_payload and not log_payload[key].startswith(("http://", "https://")):
+                log_payload[key] = f"<BASE64_DATA_LENGTH:{len(log_payload[key])}>"
+        logger.info(f"Kling V3 Multi-Shot API Request Payload: {json.dumps(log_payload, indent=2)}")
+
+        # Submit generation request
+        response = requests.post(BASE_URL, headers=headers, json=payload, timeout=30)
+        logger.info(f"Initial response status: {response.status_code}")
+        logger.info(f"Initial response text: {response.text[:500]}")
+
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError:
+            logger.error(f"HTTP Error {response.status_code}: {response.text}")
+            raise
+
+        task_id = response.json()["data"]["task_id"]
+        logger.info(f"Task created with ID: {task_id}")
+
+        # Poll for completion
+        poll_url = f"{BASE_URL}/{task_id}"
+        poll_delay = self.parameter_values.get("polling_delay", 10)
+        max_retries = 120
+        video_url = None
+
+        for attempt in range(max_retries):
+            time.sleep(poll_delay)
+
+            try:
+                result_response = requests.get(poll_url, headers=headers, timeout=30)
+                result_response.raise_for_status()
+                result = result_response.json()
+
+                status = result["data"]["task_status"]
+                logger.info(
+                    f"Kling multi-shot generation status (Task {task_id}): "
+                    f"{status} (attempt {attempt + 1}/{max_retries})"
+                )
+
+                if status == "succeed":
+                    video_url = result["data"]["task_result"]["videos"][0]["url"]
+                    logger.info(f"Video generation succeeded. URL: {video_url}")
+                    break
+                if status == "failed":
+                    error_msg = result["data"].get("task_status_msg", "Unknown error")
+                    raise RuntimeError(f"Kling multi-shot generation failed: {error_msg}")
+
+            except requests.exceptions.RequestException as e:
+                logger.warning(f"Polling request failed (attempt {attempt + 1}/{max_retries}): {e}")
+                if attempt == max_retries - 1:
+                    raise RuntimeError(f"Failed to get video status after {max_retries} attempts: {e}") from e
+
+        if not video_url:
+            raise RuntimeError("Video generation timed out — no video URL received.")
+
+        # Download and save to static storage
+        try:
+            download_response = requests.get(video_url, timeout=60)
+            download_response.raise_for_status()
+            video_bytes = download_response.content
+        except requests.exceptions.RequestException as e:
+            raise RuntimeError(f"Failed to download generated video: {e}") from e
+
+        timestamp = int(time.time() * 1000)
+        filename = f"kling_v3_multi_shot_{timestamp}.mp4"
+        static_files_manager = GriptapeNodes.StaticFilesManager()
+        saved_url = static_files_manager.save_static_file(video_bytes, filename, ExistingFilePolicy.CREATE_NEW)
+
+        video_artifact = VideoUrlArtifact(saved_url)
+        logger.info(f"Saved multi-shot video as {filename}. URL: {saved_url}")
+
+        self.publish_update_to_parameter("video_url", video_artifact)
+
+        return video_artifact

--- a/kling/widgets/MultiShotEditor.js
+++ b/kling/widgets/MultiShotEditor.js
@@ -263,11 +263,11 @@ export default function MultiShotEditor(container, props) {
         e.target.value.length >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#555";
       textarea.style.borderColor =
         e.target.value.length >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#555";
-      emitChange();
     });
-    // Prevent node-level drag when interacting with the textarea
+    // Prevent node-level drag and keyboard shortcuts (e.g. Delete deleting the node)
     textarea.addEventListener("pointerdown", (e) => e.stopPropagation());
     textarea.addEventListener("mousedown", (e) => e.stopPropagation());
+    textarea.addEventListener("keydown", (e) => e.stopPropagation());
 
     item.appendChild(textarea);
 

--- a/kling/widgets/MultiShotEditor.js
+++ b/kling/widgets/MultiShotEditor.js
@@ -555,8 +555,8 @@ export default function MultiShotEditor(container, props) {
           element.innerHTML = val;
         } else if (key === "className") {
           element.className = val;
-        } else if (key === "disabled" && val) {
-          element.disabled = true;
+        } else if (key === "disabled") {
+          element.disabled = !!val;
         } else if (key === "placeholder") {
           element.placeholder = val;
         } else if (key === "value") {

--- a/kling/widgets/MultiShotEditor.js
+++ b/kling/widgets/MultiShotEditor.js
@@ -4,7 +4,7 @@
  * and per-shot description text.
  */
 
-const WIDGET_VERSION = "0.2.1";
+const WIDGET_VERSION = "0.2.2";
 
 export default function MultiShotEditor(container, props) {
   const { value, onChange, disabled } = props;
@@ -22,7 +22,7 @@ export default function MultiShotEditor(container, props) {
   const MAX_DESCRIPTION_LENGTH = 512;
   const MAX_TOTAL_DURATION = 15;
   const MIN_DURATION = 1;
-  const MAX_DURATION = 10;
+  const MAX_DURATION = 15;
   const PLACEHOLDER =
     "Describe the shot information, such as: who is where and what is happening.";
 

--- a/kling/widgets/MultiShotEditor.js
+++ b/kling/widgets/MultiShotEditor.js
@@ -1,0 +1,592 @@
+/**
+ * MultiShotEditor - A list-based editor for managing video shot sequences.
+ * Supports adding, deleting, reordering (drag-and-drop), duration selection,
+ * and per-shot description text.
+ */
+
+export default function MultiShotEditor(container, props) {
+  const { value, onChange, disabled } = props;
+
+  let shots =
+    Array.isArray(value) && value.length > 0
+      ? value.map((s) => ({ ...s }))
+      : [{ name: "Shot1", duration: 2, description: "" }];
+
+  let dragSourceIndex = null;
+  let dragOverIndex = null;
+  let openDropdownIndex = null;
+
+  const MAX_SHOTS = 6;
+  const MIN_SHOTS = 1;
+  const MAX_DESCRIPTION_LENGTH = 512;
+  const MAX_TOTAL_DURATION = 15;
+  const DURATION_OPTIONS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+  const PLACEHOLDER =
+    "Describe the shot information, such as: who is where and what is happening.";
+
+  // ── helpers ──────────────────────────────────────────────────────────
+
+  function renumberShots() {
+    shots.forEach((shot, i) => {
+      shot.name = `Shot${i + 1}`;
+    });
+  }
+
+  function totalDuration() {
+    return shots.reduce((sum, s) => sum + (s.duration || 0), 0);
+  }
+
+  function durationBudgetFor(index) {
+    const othersTotal = shots.reduce(
+      (sum, s, i) => sum + (i === index ? 0 : s.duration || 0),
+      0,
+    );
+    return MAX_TOTAL_DURATION - othersTotal;
+  }
+
+  function emitChange() {
+    if (disabled || !onChange) return;
+    onChange(shots.map((s) => ({ ...s })));
+  }
+
+  // ── close any open dropdown when clicking outside ───────────────────
+
+  function onDocumentClick(e) {
+    if (openDropdownIndex !== null && !e.target.closest(".duration-badge")) {
+      openDropdownIndex = null;
+      render();
+    }
+  }
+  document.addEventListener("pointerdown", onDocumentClick, true);
+
+  // ── render ──────────────────────────────────────────────────────────
+
+  function render() {
+    container.innerHTML = "";
+
+    const wrapper = el("div", {
+      className: "multi-shot-container nodrag nowheel",
+      style: `
+        display: flex;
+        flex-direction: column;
+        gap: 0;
+        padding: 8px;
+        background-color: #1a1a1a;
+        border-radius: 6px;
+        user-select: none;
+        box-sizing: border-box;
+        width: 100%;
+      `,
+    });
+
+    shots.forEach((shot, index) => {
+      wrapper.appendChild(buildShotItem(shot, index));
+    });
+
+    wrapper.appendChild(buildStatusBar());
+    wrapper.appendChild(buildAddButton());
+    container.appendChild(wrapper);
+  }
+
+  // ── shot item ───────────────────────────────────────────────────────
+
+  function buildShotItem(shot, index) {
+    const item = el("div", {
+      className: "shot-item",
+      "data-index": index,
+      style: `
+        display: flex;
+        flex-direction: column;
+        gap: 0;
+        border-bottom: 1px solid #2a2a2a;
+        padding-bottom: 8px;
+        margin-bottom: 8px;
+        ${dragOverIndex === index ? "border-top: 2px solid #4a9eff;" : ""}
+      `,
+    });
+
+    // ── header row ──
+    const header = el("div", {
+      style: `
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        height: 32px;
+      `,
+    });
+
+    // drag handle
+    const handle = el("span", {
+      className: "drag-handle",
+      textContent: "≡",
+      style: `
+        font-size: 18px;
+        color: #666;
+        cursor: ${disabled ? "default" : "grab"};
+        flex-shrink: 0;
+        width: 20px;
+        text-align: center;
+        line-height: 1;
+      `,
+    });
+    if (!disabled) {
+      handle.addEventListener("pointerdown", (e) => onDragStart(e, index));
+    }
+    header.appendChild(handle);
+
+    // shot name badge
+    header.appendChild(
+      el("span", {
+        textContent: shot.name,
+        style: `
+          background: #333;
+          color: #ddd;
+          font-size: 12px;
+          font-weight: 600;
+          padding: 3px 10px;
+          border-radius: 4px;
+          white-space: nowrap;
+        `,
+      }),
+    );
+
+    // duration badge + dropdown
+    const durationWrapper = el("div", {
+      style: "position: relative;",
+      className: "duration-badge",
+    });
+
+    const durationBadge = el("span", {
+      textContent: `${shot.duration} s`,
+      style: `
+        background: #333;
+        color: #ddd;
+        font-size: 12px;
+        padding: 3px 10px;
+        border-radius: 4px;
+        cursor: ${disabled ? "default" : "pointer"};
+        white-space: nowrap;
+      `,
+    });
+    if (!disabled) {
+      durationBadge.addEventListener("pointerdown", (e) => {
+        e.stopPropagation();
+        openDropdownIndex = openDropdownIndex === index ? null : index;
+        render();
+      });
+    }
+    durationWrapper.appendChild(durationBadge);
+
+    if (openDropdownIndex === index) {
+      durationWrapper.appendChild(buildDurationDropdown(index));
+    }
+
+    header.appendChild(durationWrapper);
+
+    // spacer
+    header.appendChild(el("div", { style: "flex: 1;" }));
+
+    // trash button
+    if (!disabled) {
+      const trash = el("span", {
+        innerHTML: trashSVG(),
+        style: `
+          cursor: pointer;
+          flex-shrink: 0;
+          display: flex;
+          align-items: center;
+          opacity: 0.5;
+        `,
+      });
+      trash.addEventListener("pointerenter", () => {
+        trash.style.opacity = "1";
+      });
+      trash.addEventListener("pointerleave", () => {
+        trash.style.opacity = "0.5";
+      });
+      trash.addEventListener("pointerdown", (e) => {
+        e.stopPropagation();
+        if (shots.length <= 1) return;
+        shots.splice(index, 1);
+        renumberShots();
+        emitChange();
+        render();
+      });
+      header.appendChild(trash);
+    }
+
+    item.appendChild(header);
+
+    // ── description textarea ──
+    const descLength = (shot.description || "").length;
+    const textarea = el("textarea", {
+      placeholder: PLACEHOLDER,
+      value: shot.description || "",
+      disabled: disabled,
+      style: `
+        width: 100%;
+        min-height: 72px;
+        margin-top: 4px;
+        padding: 8px 10px;
+        background: #252525;
+        border: 1px solid ${descLength >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#333"};
+        border-radius: 6px;
+        color: #ccc;
+        font-size: 12px;
+        font-family: inherit;
+        resize: vertical;
+        box-sizing: border-box;
+        outline: none;
+        user-select: text;
+        -webkit-user-select: text;
+      `,
+    });
+    textarea.maxLength = MAX_DESCRIPTION_LENGTH;
+    textarea.textContent = shot.description || "";
+    textarea.addEventListener("focus", () => {
+      const len = shots[index].description.length;
+      textarea.style.borderColor =
+        len >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#555";
+    });
+    textarea.addEventListener("blur", () => {
+      const len = shots[index].description.length;
+      textarea.style.borderColor =
+        len >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#333";
+    });
+    textarea.addEventListener("input", (e) => {
+      shots[index].description = e.target.value;
+      counter.textContent = `${e.target.value.length} / ${MAX_DESCRIPTION_LENGTH}`;
+      counter.style.color =
+        e.target.value.length >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#555";
+      textarea.style.borderColor =
+        e.target.value.length >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#555";
+      emitChange();
+    });
+    // Prevent node-level drag when interacting with the textarea
+    textarea.addEventListener("pointerdown", (e) => e.stopPropagation());
+    textarea.addEventListener("mousedown", (e) => e.stopPropagation());
+
+    item.appendChild(textarea);
+
+    const counter = el("div", {
+      textContent: `${descLength} / ${MAX_DESCRIPTION_LENGTH}`,
+      style: `
+        font-size: 10px;
+        color: ${descLength >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#555"};
+        text-align: right;
+        margin-top: 2px;
+      `,
+    });
+    item.appendChild(counter);
+
+    return item;
+  }
+
+  // ── duration dropdown ───────────────────────────────────────────────
+
+  function buildDurationDropdown(index) {
+    const budget = durationBudgetFor(index);
+
+    const dropdown = el("div", {
+      style: `
+        position: absolute;
+        top: 100%;
+        left: 0;
+        margin-top: 4px;
+        background: #2a2a2a;
+        border: 1px solid #444;
+        border-radius: 6px;
+        padding: 4px 0;
+        z-index: 100;
+        min-width: 60px;
+        box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+      `,
+    });
+
+    DURATION_OPTIONS.forEach((dur) => {
+      const isSelected = shots[index].duration === dur;
+      const isAllowed = dur <= budget;
+
+      const option = el("div", {
+        textContent: `${dur} s`,
+        style: `
+          padding: 4px 12px;
+          font-size: 12px;
+          color: ${isSelected ? "#fff" : isAllowed ? "#aaa" : "#555"};
+          background: ${isSelected ? "#444" : "transparent"};
+          cursor: ${isAllowed ? "pointer" : "default"};
+          white-space: nowrap;
+          opacity: ${isAllowed ? 1 : 0.4};
+        `,
+      });
+
+      if (isAllowed) {
+        option.addEventListener("pointerenter", () => {
+          if (!isSelected) option.style.background = "#333";
+        });
+        option.addEventListener("pointerleave", () => {
+          option.style.background = isSelected ? "#444" : "transparent";
+        });
+        option.addEventListener("pointerdown", (e) => {
+          e.stopPropagation();
+          shots[index].duration = dur;
+          openDropdownIndex = null;
+          emitChange();
+          render();
+        });
+      } else {
+        option.addEventListener("pointerdown", (e) => e.stopPropagation());
+      }
+
+      dropdown.appendChild(option);
+    });
+
+    return dropdown;
+  }
+
+  // ── status bar ──────────────────────────────────────────────────────
+
+  function buildStatusBar() {
+    const total = totalDuration();
+    const overBudget = total > MAX_TOTAL_DURATION;
+
+    const bar = el("div", {
+      style: `
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-size: 10px;
+        color: #666;
+        padding: 4px 2px;
+        margin-bottom: 2px;
+      `,
+    });
+
+    bar.appendChild(
+      el("span", {
+        textContent: `${shots.length} / ${MAX_SHOTS} shots`,
+      }),
+    );
+
+    bar.appendChild(
+      el("span", {
+        textContent: `${total} / ${MAX_TOTAL_DURATION} s`,
+        style: `color: ${overBudget ? "#c44" : "#666"};`,
+      }),
+    );
+
+    return bar;
+  }
+
+  // ── add-shot button ─────────────────────────────────────────────────
+
+  function buildAddButton() {
+    const atMaxShots = shots.length >= MAX_SHOTS;
+    const remaining = MAX_TOTAL_DURATION - totalDuration();
+    const cannotFitAnother = remaining < 1;
+    const addDisabled = disabled || atMaxShots || cannotFitAnother;
+
+    const btn = el("div", {
+      style: `
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        padding: 5px 12px;
+        margin-top: 4px;
+        background: #252525;
+        border: 1px solid #333;
+        border-radius: 6px;
+        color: #ccc;
+        font-size: 12px;
+        cursor: ${addDisabled ? "not-allowed" : "pointer"};
+        opacity: ${addDisabled ? 0.4 : 1};
+        align-self: flex-start;
+        user-select: none;
+      `,
+    });
+    btn.innerHTML = `<span style="font-size:14px;">+</span> Shot`;
+
+    if (!addDisabled) {
+      btn.addEventListener("pointerenter", () => {
+        btn.style.background = "#333";
+      });
+      btn.addEventListener("pointerleave", () => {
+        btn.style.background = "#252525";
+      });
+      btn.addEventListener("pointerdown", (e) => {
+        e.stopPropagation();
+        const defaultDur = Math.min(2, remaining);
+        shots.push({
+          name: `Shot${shots.length + 1}`,
+          duration: defaultDur,
+          description: "",
+        });
+        emitChange();
+        render();
+      });
+    }
+
+    return btn;
+  }
+
+  // ── drag-and-drop reordering ────────────────────────────────────────
+
+  let dragClone = null;
+  let dragOffsetY = 0;
+  let shotItems = [];
+
+  function onDragStart(e, index) {
+    if (disabled) return;
+    e.preventDefault();
+    e.stopPropagation();
+
+    dragSourceIndex = index;
+    dragOverIndex = null;
+
+    const itemEl = e.target.closest(".shot-item");
+    if (!itemEl) return;
+
+    const rect = itemEl.getBoundingClientRect();
+    dragOffsetY = e.clientY - rect.top;
+
+    // Create a floating clone for visual feedback
+    dragClone = itemEl.cloneNode(true);
+    dragClone.style.position = "fixed";
+    dragClone.style.left = `${rect.left}px`;
+    dragClone.style.top = `${rect.top}px`;
+    dragClone.style.width = `${rect.width}px`;
+    dragClone.style.opacity = "0.85";
+    dragClone.style.pointerEvents = "none";
+    dragClone.style.zIndex = "9999";
+    dragClone.style.boxShadow = "0 4px 16px rgba(0,0,0,0.6)";
+    dragClone.style.background = "#1a1a1a";
+    dragClone.style.borderRadius = "6px";
+    document.body.appendChild(dragClone);
+
+    // Dim the original
+    itemEl.style.opacity = "0.3";
+
+    // Collect all shot item rects for hit testing
+    shotItems = Array.from(container.querySelectorAll(".shot-item")).map(
+      (el) => ({
+        el,
+        rect: el.getBoundingClientRect(),
+        index: Number(el.dataset.index),
+      }),
+    );
+
+    document.addEventListener("pointermove", onDragMove);
+    document.addEventListener("pointerup", onDragEnd);
+  }
+
+  function onDragMove(e) {
+    if (dragSourceIndex === null || !dragClone) return;
+    e.preventDefault();
+
+    dragClone.style.top = `${e.clientY - dragOffsetY}px`;
+
+    // Determine which item we're hovering over
+    let newOverIndex = null;
+    for (const item of shotItems) {
+      const midY = item.rect.top + item.rect.height / 2;
+      if (e.clientY < midY) {
+        newOverIndex = item.index;
+        break;
+      }
+    }
+    if (newOverIndex === null) {
+      newOverIndex = shots.length;
+    }
+
+    if (newOverIndex !== dragOverIndex) {
+      dragOverIndex = newOverIndex;
+      // Update visual indicators on existing items
+      shotItems.forEach((item) => {
+        if (item.index === dragOverIndex && item.index !== dragSourceIndex) {
+          item.el.style.borderTop = "2px solid #4a9eff";
+        } else {
+          item.el.style.borderTop = "none";
+        }
+      });
+    }
+  }
+
+  function onDragEnd(e) {
+    document.removeEventListener("pointermove", onDragMove);
+    document.removeEventListener("pointerup", onDragEnd);
+
+    if (dragClone) {
+      dragClone.remove();
+      dragClone = null;
+    }
+
+    if (
+      dragSourceIndex !== null &&
+      dragOverIndex !== null &&
+      dragOverIndex !== dragSourceIndex
+    ) {
+      const [moved] = shots.splice(dragSourceIndex, 1);
+      const insertAt =
+        dragOverIndex > dragSourceIndex ? dragOverIndex - 1 : dragOverIndex;
+      shots.splice(insertAt, 0, moved);
+      renumberShots();
+      emitChange();
+    }
+
+    dragSourceIndex = null;
+    dragOverIndex = null;
+    shotItems = [];
+    render();
+  }
+
+  // ── DOM helper ──────────────────────────────────────────────────────
+
+  function el(tag, attrs) {
+    const element = document.createElement(tag);
+    if (attrs) {
+      Object.entries(attrs).forEach(([key, val]) => {
+        if (key === "style") {
+          element.setAttribute("style", val);
+        } else if (key === "textContent") {
+          element.textContent = val;
+        } else if (key === "innerHTML") {
+          element.innerHTML = val;
+        } else if (key === "className") {
+          element.className = val;
+        } else if (key === "disabled" && val) {
+          element.disabled = true;
+        } else if (key === "placeholder") {
+          element.placeholder = val;
+        } else if (key === "value") {
+          element.value = val;
+        } else {
+          element.setAttribute(key, val);
+        }
+      });
+    }
+    return element;
+  }
+
+  function trashSVG() {
+    return `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#888" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <polyline points="3 6 5 6 21 6"/>
+      <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
+    </svg>`;
+  }
+
+  // ── init ─────────────────────────────────────────────────────────────
+
+  render();
+
+  // ── cleanup ─────────────────────────────────────────────────────────
+
+  return () => {
+    document.removeEventListener("pointerdown", onDocumentClick, true);
+    document.removeEventListener("pointermove", onDragMove);
+    document.removeEventListener("pointerup", onDragEnd);
+    if (dragClone) {
+      dragClone.remove();
+      dragClone = null;
+    }
+  };
+}

--- a/kling/widgets/MultiShotEditor.js
+++ b/kling/widgets/MultiShotEditor.js
@@ -4,7 +4,7 @@
  * and per-shot description text.
  */
 
-const WIDGET_VERSION = "0.6.0";
+const WIDGET_VERSION = "0.6.1";
 
 export default function MultiShotEditor(container, props) {
   const { value, onChange, disabled } = props;
@@ -233,6 +233,11 @@ export default function MultiShotEditor(container, props) {
         if (shots.length <= 1) return;
         shots.splice(index, 1);
         renumberShots();
+        const total = totalDuration();
+        if (total < MIN_TOTAL_DURATION) {
+          const lastShot = shots[shots.length - 1];
+          lastShot.duration += MIN_TOTAL_DURATION - total;
+        }
         emitChange();
         render();
       });

--- a/kling/widgets/MultiShotEditor.js
+++ b/kling/widgets/MultiShotEditor.js
@@ -4,7 +4,7 @@
  * and per-shot description text.
  */
 
-const WIDGET_VERSION = "0.3.0";
+const WIDGET_VERSION = "0.3.1";
 
 export default function MultiShotEditor(container, props) {
   const { value, onChange, disabled } = props;
@@ -514,12 +514,17 @@ export default function MultiShotEditor(container, props) {
 
     if (newOverIndex !== dragOverIndex) {
       dragOverIndex = newOverIndex;
-      // Update visual indicators on existing items
+      const lastIndex = shots.length - 1;
       shotItems.forEach((item) => {
-        if (item.index === dragOverIndex && item.index !== dragSourceIndex) {
+        item.el.style.borderTop = "none";
+        item.el.style.borderBottom = "1px solid #2a2a2a";
+
+        if (item.index === dragSourceIndex) return;
+
+        if (dragOverIndex === shots.length && item.index === lastIndex) {
+          item.el.style.borderBottom = "2px solid #4a9eff";
+        } else if (item.index === dragOverIndex) {
           item.el.style.borderTop = "2px solid #4a9eff";
-        } else {
-          item.el.style.borderTop = "none";
         }
       });
     }

--- a/kling/widgets/MultiShotEditor.js
+++ b/kling/widgets/MultiShotEditor.js
@@ -263,6 +263,7 @@ export default function MultiShotEditor(container, props) {
         e.target.value.length >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#555";
       textarea.style.borderColor =
         e.target.value.length >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#555";
+      emitChange();
     });
     // Prevent node-level drag when interacting with the textarea
     textarea.addEventListener("pointerdown", (e) => e.stopPropagation());

--- a/kling/widgets/MultiShotEditor.js
+++ b/kling/widgets/MultiShotEditor.js
@@ -263,6 +263,7 @@ export default function MultiShotEditor(container, props) {
         e.target.value.length >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#555";
       textarea.style.borderColor =
         e.target.value.length >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#555";
+      emitChange();
     });
     // Prevent node-level drag and keyboard shortcuts (e.g. Delete deleting the node)
     textarea.addEventListener("pointerdown", (e) => e.stopPropagation());

--- a/kling/widgets/MultiShotEditor.js
+++ b/kling/widgets/MultiShotEditor.js
@@ -4,7 +4,7 @@
  * and per-shot description text.
  */
 
-const WIDGET_VERSION = "0.2.0";
+const WIDGET_VERSION = "0.2.1";
 
 export default function MultiShotEditor(container, props) {
   const { value, onChange, disabled } = props;
@@ -186,9 +186,9 @@ export default function MultiShotEditor(container, props) {
       render();
     });
 
-    stepper.appendChild(decBtn);
-    stepper.appendChild(durationLabel);
     stepper.appendChild(incBtn);
+    stepper.appendChild(durationLabel);
+    stepper.appendChild(decBtn);
     header.appendChild(stepper);
 
     // spacer

--- a/kling/widgets/MultiShotEditor.js
+++ b/kling/widgets/MultiShotEditor.js
@@ -4,7 +4,7 @@
  * and per-shot description text.
  */
 
-const WIDGET_VERSION = "0.5.0";
+const WIDGET_VERSION = "0.6.0";
 
 export default function MultiShotEditor(container, props) {
   const { value, onChange, disabled } = props;
@@ -26,7 +26,7 @@ export default function MultiShotEditor(container, props) {
   let shots =
     Array.isArray(value) && value.length > 0
       ? value.map((s) => assignId({ ...s }))
-      : [assignId({ name: "Shot1", duration: 2, description: "" })];
+      : [assignId({ name: "Shot1", duration: 3, description: "" })];
 
   let dragSourceIndex = null;
   let dragOverIndex = null;
@@ -35,6 +35,7 @@ export default function MultiShotEditor(container, props) {
   const MIN_SHOTS = 1;
   const MAX_DESCRIPTION_LENGTH = 512;
   const MAX_TOTAL_DURATION = 15;
+  const MIN_TOTAL_DURATION = 3;
   const MIN_DURATION = 1;
   const MAX_DURATION = 15;
   const PLACEHOLDER =
@@ -159,8 +160,9 @@ export default function MultiShotEditor(container, props) {
 
     // duration stepper (▲ value ▼)
     const budget = durationBudgetFor(index);
+    const wouldGoBelow = totalDuration() - 1 < MIN_TOTAL_DURATION;
     const canIncrease = !disabled && shot.duration < MAX_DURATION && shot.duration < budget;
-    const canDecrease = !disabled && shot.duration > MIN_DURATION;
+    const canDecrease = !disabled && shot.duration > MIN_DURATION && !wouldGoBelow;
 
     const stepper = el("div", {
       style: `
@@ -346,6 +348,8 @@ export default function MultiShotEditor(container, props) {
   function buildStatusBar() {
     const total = totalDuration();
     const overBudget = total > MAX_TOTAL_DURATION;
+    const underBudget = total < MIN_TOTAL_DURATION;
+    const durationColor = overBudget || underBudget ? "#c44" : "#666";
 
     const bar = el("div", {
       style: `
@@ -367,8 +371,8 @@ export default function MultiShotEditor(container, props) {
 
     bar.appendChild(
       el("span", {
-        textContent: `${total} / ${MAX_TOTAL_DURATION} s`,
-        style: `color: ${overBudget ? "#c44" : "#666"};`,
+        textContent: `${total}s (${MIN_TOTAL_DURATION}–${MAX_TOTAL_DURATION}s)`,
+        style: `color: ${durationColor};`,
       }),
     );
 

--- a/kling/widgets/MultiShotEditor.js
+++ b/kling/widgets/MultiShotEditor.js
@@ -4,6 +4,8 @@
  * and per-shot description text.
  */
 
+const WIDGET_VERSION = "0.1.0";
+
 export default function MultiShotEditor(container, props) {
   const { value, onChange, disabled } = props;
 
@@ -85,6 +87,7 @@ export default function MultiShotEditor(container, props) {
 
     wrapper.appendChild(buildStatusBar());
     wrapper.appendChild(buildAddButton());
+    wrapper.appendChild(buildVersionLabel());
     container.appendChild(wrapper);
   }
 
@@ -431,6 +434,20 @@ export default function MultiShotEditor(container, props) {
     }
 
     return btn;
+  }
+
+  // ── version label ──────────────────────────────────────────────────
+
+  function buildVersionLabel() {
+    return el("div", {
+      textContent: `v${WIDGET_VERSION}`,
+      style: `
+        font-size: 9px;
+        color: #444;
+        text-align: right;
+        margin-top: 4px;
+      `,
+    });
   }
 
   // ── drag-and-drop reordering ────────────────────────────────────────

--- a/kling/widgets/MultiShotEditor.js
+++ b/kling/widgets/MultiShotEditor.js
@@ -4,7 +4,7 @@
  * and per-shot description text.
  */
 
-const WIDGET_VERSION = "0.3.2";
+const WIDGET_VERSION = "0.3.3";
 
 export default function MultiShotEditor(container, props) {
   const { value, onChange, disabled } = props;
@@ -276,7 +276,6 @@ export default function MultiShotEditor(container, props) {
         len >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#333";
       counter.textContent = `${len} / ${MAX_DESCRIPTION_LENGTH}`;
       counter.style.color = len >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#555";
-      emitChange();
     });
     textarea.addEventListener("input", (e) => {
       shots[index].description = e.target.value;
@@ -285,6 +284,16 @@ export default function MultiShotEditor(container, props) {
         e.target.value.length >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#555";
       textarea.style.borderColor =
         e.target.value.length >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#555";
+
+      const selStart = textarea.selectionStart;
+      const selEnd = textarea.selectionEnd;
+      emitChange();
+      requestAnimationFrame(() => {
+        if (document.body.contains(textarea)) {
+          textarea.focus();
+          textarea.setSelectionRange(selStart, selEnd);
+        }
+      });
     });
     // Prevent node-level drag and keyboard shortcuts (e.g. Delete deleting the node)
     textarea.addEventListener("pointerdown", (e) => e.stopPropagation());

--- a/kling/widgets/MultiShotEditor.js
+++ b/kling/widgets/MultiShotEditor.js
@@ -4,15 +4,29 @@
  * and per-shot description text.
  */
 
-const WIDGET_VERSION = "0.2.2";
+const WIDGET_VERSION = "0.3.0";
 
 export default function MultiShotEditor(container, props) {
   const { value, onChange, disabled } = props;
 
+  let nextShotId = 1;
+
+  function assignId(shot) {
+    if (!shot.id) {
+      shot.id = `shot-${nextShotId++}`;
+    } else {
+      const num = parseInt(shot.id.replace("shot-", ""), 10);
+      if (!isNaN(num) && num >= nextShotId) {
+        nextShotId = num + 1;
+      }
+    }
+    return shot;
+  }
+
   let shots =
     Array.isArray(value) && value.length > 0
-      ? value.map((s) => ({ ...s }))
-      : [{ name: "Shot1", duration: 2, description: "" }];
+      ? value.map((s) => assignId({ ...s }))
+      : [assignId({ name: "Shot1", duration: 2, description: "" })];
 
   let dragSourceIndex = null;
   let dragOverIndex = null;
@@ -400,11 +414,13 @@ export default function MultiShotEditor(container, props) {
       btn.addEventListener("pointerdown", (e) => {
         e.stopPropagation();
         const defaultDur = Math.min(2, remaining);
-        shots.push({
-          name: `Shot${shots.length + 1}`,
-          duration: defaultDur,
-          description: "",
-        });
+        shots.push(
+          assignId({
+            name: `Shot${shots.length + 1}`,
+            duration: defaultDur,
+            description: "",
+          }),
+        );
         emitChange();
         render();
       });

--- a/kling/widgets/MultiShotEditor.js
+++ b/kling/widgets/MultiShotEditor.js
@@ -242,16 +242,19 @@ export default function MultiShotEditor(container, props) {
       `,
     });
     textarea.maxLength = MAX_DESCRIPTION_LENGTH;
-    textarea.textContent = shot.description || "";
     textarea.addEventListener("focus", () => {
       const len = shots[index].description.length;
       textarea.style.borderColor =
         len >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#555";
     });
     textarea.addEventListener("blur", () => {
-      const len = shots[index].description.length;
+      shots[index].description = textarea.value;
+      const len = textarea.value.length;
       textarea.style.borderColor =
         len >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#333";
+      counter.textContent = `${len} / ${MAX_DESCRIPTION_LENGTH}`;
+      counter.style.color = len >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#555";
+      emitChange();
     });
     textarea.addEventListener("input", (e) => {
       shots[index].description = e.target.value;
@@ -260,7 +263,6 @@ export default function MultiShotEditor(container, props) {
         e.target.value.length >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#555";
       textarea.style.borderColor =
         e.target.value.length >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#555";
-      emitChange();
     });
     // Prevent node-level drag when interacting with the textarea
     textarea.addEventListener("pointerdown", (e) => e.stopPropagation());

--- a/kling/widgets/MultiShotEditor.js
+++ b/kling/widgets/MultiShotEditor.js
@@ -4,7 +4,7 @@
  * and per-shot description text.
  */
 
-const WIDGET_VERSION = "0.3.3";
+const WIDGET_VERSION = "0.4.0";
 
 export default function MultiShotEditor(container, props) {
   const { value, onChange, disabled } = props;

--- a/kling/widgets/MultiShotEditor.js
+++ b/kling/widgets/MultiShotEditor.js
@@ -4,7 +4,7 @@
  * and per-shot description text.
  */
 
-const WIDGET_VERSION = "0.3.1";
+const WIDGET_VERSION = "0.3.2";
 
 export default function MultiShotEditor(container, props) {
   const { value, onChange, disabled } = props;
@@ -285,7 +285,6 @@ export default function MultiShotEditor(container, props) {
         e.target.value.length >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#555";
       textarea.style.borderColor =
         e.target.value.length >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#555";
-      emitChange();
     });
     // Prevent node-level drag and keyboard shortcuts (e.g. Delete deleting the node)
     textarea.addEventListener("pointerdown", (e) => e.stopPropagation());

--- a/kling/widgets/MultiShotEditor.js
+++ b/kling/widgets/MultiShotEditor.js
@@ -4,7 +4,7 @@
  * and per-shot description text.
  */
 
-const WIDGET_VERSION = "0.4.0";
+const WIDGET_VERSION = "0.5.0";
 
 export default function MultiShotEditor(container, props) {
   const { value, onChange, disabled } = props;
@@ -276,6 +276,7 @@ export default function MultiShotEditor(container, props) {
         len >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#333";
       counter.textContent = `${len} / ${MAX_DESCRIPTION_LENGTH}`;
       counter.style.color = len >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#555";
+      emitChange();
     });
     textarea.addEventListener("input", (e) => {
       shots[index].description = e.target.value;
@@ -284,16 +285,6 @@ export default function MultiShotEditor(container, props) {
         e.target.value.length >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#555";
       textarea.style.borderColor =
         e.target.value.length >= MAX_DESCRIPTION_LENGTH ? "#c44" : "#555";
-
-      const selStart = textarea.selectionStart;
-      const selEnd = textarea.selectionEnd;
-      emitChange();
-      requestAnimationFrame(() => {
-        if (document.body.contains(textarea)) {
-          textarea.focus();
-          textarea.setSelectionRange(selStart, selEnd);
-        }
-      });
     });
     // Prevent node-level drag and keyboard shortcuts (e.g. Delete deleting the node)
     textarea.addEventListener("pointerdown", (e) => e.stopPropagation());


### PR DESCRIPTION
## Summary

- **New node: `KlingV3MultiShot`** — generates multi-shot videos using the Kling v3 API with per-shot prompts and durations via the `multi_prompt` parameter
- **New custom widget: `MultiShotEditor`** — interactive shot list editor with drag-and-drop reordering, stepper-based duration controls (▲/▼), per-shot text descriptions, character counters, and validation status bar
- Automatically selects `image2video` or `text2video` endpoint based on whether input images are provided
- Enforces constraints: max 6 shots, 1–15s per shot, 3–15s total duration, 512 char max per description
- Also includes earlier commits adding kling-v3 model support (duration slider, end-frame) to the existing image-to-video and text-to-video nodes

### Key files

- `kling/kling_v3_multi_shot.py` — the node (ControlNode with async API calls, JWT auth, polling, video download)
- `kling/widgets/MultiShotEditor.js` — the custom UI widget (v0.6.1)
- `kling/griptape_nodes_library.json` — updated with widget registration and node entry

## Test plan

- [ ] Add node to canvas, verify shot list UI renders with default shot
- [ ] Add/remove shots, verify constraints (max 6, min total 3s, max total 15s)
- [ ] Drag-and-drop reorder shots, verify text and durations are preserved
- [ ] Test text-to-video mode (no images) — verify `text2video` endpoint is used
- [ ] Test image-to-video mode (with start_frame) — verify `image2video` endpoint is used
- [ ] Run a generation and verify video output is returned
- [ ] Verify existing image-to-video and text-to-video nodes still work with kling-v3 model selection