### PR TITLE
feat: replace bespoke loading logic with File class

### DIFF
--- a/kling/griptape_nodes_library.json
+++ b/kling/griptape_nodes_library.json
@@ -17,7 +17,7 @@
         "author": "Griptape",
         "description": "Nodes for interacting with the Kling AI API",
         "library_version": "0.1.3",
-        "engine_version": "0.66.0",
+        "engine_version": "0.75.0",
         "tags": [
             "Griptape",
             "AI",

--- a/kling/image_to_video.py
+++ b/kling/image_to_video.py
@@ -13,6 +13,7 @@ from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, Parame
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
 from griptape_nodes.retained_mode.griptape_nodes import logger, GriptapeNodes
 from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
+from griptape_nodes.files.file import File, FileLoadError
 
 SERVICE = "Kling"
 API_KEY_ENV_VAR = "KLING_ACCESS_KEY"
@@ -605,12 +606,7 @@ class KlingAI_ImageToVideo(ControlNode):
                 raise RuntimeError("Kling video generation task finished but no video URL was found or task timed out.")
 
             # Download the generated video and save to static storage
-            try:
-                download_response = requests.get(video_url, timeout=60)
-                download_response.raise_for_status()
-                video_bytes = download_response.content
-            except requests.exceptions.RequestException as e:
-                raise RuntimeError(f"Failed to download generated video: {e}") from e
+            video_bytes = File(video_url).read_bytes()
 
             timestamp = int(time.time() * 1000)
             filename = f"kling_image_to_video_{timestamp}_{job_index}.mp4"

--- a/kling/image_to_video.py
+++ b/kling/image_to_video.py
@@ -321,10 +321,9 @@ class KlingAI_ImageToVideo(ControlNode):
             if is_local_http and url_string.startswith("http"):
                 try:
                     logger.info(f"_get_image_api_data: Converting local URL {url_string} to Base64.")
-                    response = requests.get(url_string, timeout=10)  # Fetch content from local URL
-                    response.raise_for_status()
-                    return base64.b64encode(response.content).decode("utf-8")  # Return Base64
-                except requests.exceptions.RequestException as e:
+                    image_data = File(url_string).read_bytes()
+                    return base64.b64encode(image_data).decode("utf-8")  # Return Base64
+                except FileLoadError as e:
                     logger.error(
                         f"_get_image_api_data: Failed to fetch local URL {url_string} for Base64 conversion: {e}"
                     )

--- a/kling/lip_sync.py
+++ b/kling/lip_sync.py
@@ -10,6 +10,7 @@ from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, Parame
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
 from griptape_nodes.retained_mode.griptape_nodes import logger, GriptapeNodes
 from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
+from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.traits.file_system_picker import FileSystemPicker
 
 SERVICE = "Kling"
@@ -557,12 +558,7 @@ class KlingAI_LipSync(ControlNode):
                         logger.info(f"Kling lip-sync succeeded: {video_url}")
 
                         # Download the generated video and save to static storage
-                        try:
-                            download_response = requests.get(video_url, timeout=60)
-                            download_response.raise_for_status()
-                            video_bytes = download_response.content
-                        except requests.exceptions.RequestException as e:
-                            raise RuntimeError(f"Failed to download generated lip-sync video: {e}") from e
+                        video_bytes = File(video_url).read_bytes()
 
                         filename = f"kling_lip_sync_{int(time.time())}.mp4"
                         static_files_manager = GriptapeNodes.StaticFilesManager()

--- a/kling/motion_control.py
+++ b/kling/motion_control.py
@@ -10,6 +10,7 @@ from griptape_nodes.exe_types.node_types import SuccessFailureNode
 from griptape_nodes.exe_types.param_types.parameter_bool import ParameterBool
 from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.traits.options import Options
@@ -419,10 +420,8 @@ class KlingAI_MotionControl(SuccessFailureNode):
             self.parameter_output_values["kling_video_id"] = video_id
 
         try:
-            download_response = requests.get(download_url, timeout=60)
-            download_response.raise_for_status()
-            video_bytes = download_response.content
-        except requests.exceptions.RequestException as exc:
+            video_bytes = File(download_url).read_bytes()
+        except FileLoadError as exc:
             logger.warning("%s failed to download video: %s", self.name, exc)
             self.parameter_output_values["video_url"] = VideoUrlArtifact(download_url)
             self._set_status_results(

--- a/kling/motion_control.py
+++ b/kling/motion_control.py
@@ -284,10 +284,9 @@ class KlingAI_MotionControl(SuccessFailureNode):
         is_relative_static = url_string.startswith("/static/")
         if is_local_http or is_relative_static:
             try:
-                response = requests.get(url_string, timeout=10)
-                response.raise_for_status()
-                return base64.b64encode(response.content).decode("utf-8")
-            except requests.exceptions.RequestException as exc:
+                image_data = File(url_string).read_bytes()
+                return base64.b64encode(image_data).decode("utf-8")
+            except FileLoadError as exc:
                 logger.warning("Failed to load local image URL %s: %s", url_string, exc)
                 return url_string
 

--- a/kling/text_to_video.py
+++ b/kling/text_to_video.py
@@ -12,6 +12,7 @@ from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, Parame
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
 from griptape_nodes.retained_mode.griptape_nodes import logger, GriptapeNodes
 from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
+from griptape_nodes.files.file import File, FileLoadError
 
 
 SERVICE = "Kling"
@@ -486,12 +487,7 @@ class KlingAI_TextToVideo(ControlNode):
                 raise RuntimeError(f"Video generation timed out after {max_retries * 5 / 60:.1f} minutes. Task may still be processing.")
 
             # Download the generated video and save to static storage
-            try:
-                download_response = requests.get(video_url, timeout=60)
-                download_response.raise_for_status()
-                video_bytes = download_response.content
-            except requests.exceptions.RequestException as e:
-                raise RuntimeError(f"Failed to download generated video: {e}") from e
+            video_bytes = File(video_url).read_bytes()
 
             timestamp = int(time.time() * 1000)
             filename = f"kling_text_to_video_{timestamp}_{job_index}.mp4"

--- a/kling/video_extension.py
+++ b/kling/video_extension.py
@@ -9,6 +9,7 @@ from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, Parame
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
 from griptape_nodes.retained_mode.griptape_nodes import logger, GriptapeNodes
 from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
+from griptape_nodes.files.file import File, FileLoadError
 
 SERVICE = "Kling"
 API_KEY_ENV_VAR = "KLING_ACCESS_KEY"
@@ -215,12 +216,7 @@ class KlingAI_VideoExtension(ControlNode):
                         logger.info(f"Kling video extension succeeded: {video_url}")
                         
                         # Download the generated video and save to static storage
-                        try:
-                            download_response = requests.get(video_url, timeout=60)
-                            download_response.raise_for_status()
-                            video_bytes = download_response.content
-                        except requests.exceptions.RequestException as e:
-                            raise RuntimeError(f"Failed to download extended video: {e}") from e
+                        video_bytes = File(video_url).read_bytes()
 
                         filename = f"kling_video_extension_{int(time.time())}.mp4"
                         static_files_manager = GriptapeNodes.StaticFilesManager()


### PR DESCRIPTION
## Summary
- Replace `requests.get` video/image download calls with `File(url).read_bytes()`
- Bump `engine_version` to `0.75.0`
- API polling GET calls are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)