### PR TITLE
feat: migrate save_static_file to ProjectFileParameter

### DIFF
--- a/kling/image_to_video.py
+++ b/kling/image_to_video.py
@@ -11,8 +11,8 @@ from griptape_nodes.traits.slider import Slider
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, ParameterGroup
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.retained_mode.griptape_nodes import logger, GriptapeNodes
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.files.file import File, FileLoadError
 
 SERVICE = "Kling"
@@ -35,6 +35,8 @@ def encode_jwt_token(ak: str, sk: str) -> str:
 class KlingAI_ImageToVideo(ControlNode):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="kling_video.mp4")
+        self._output_file.add_parameter()
         self.category = "AI/Kling"
         self.description = "Generates a video from an image using Kling AI."
 
@@ -604,17 +606,15 @@ class KlingAI_ImageToVideo(ControlNode):
                 )
                 raise RuntimeError("Kling video generation task finished but no video URL was found or task timed out.")
 
-            # Download the generated video and save to static storage
+            # Download the generated video and save to project storage
             video_bytes = File(video_url).read_bytes()
 
-            timestamp = int(time.time() * 1000)
-            filename = f"kling_image_to_video_{timestamp}_{job_index}.mp4"
-            static_files_manager = GriptapeNodes.StaticFilesManager()
-            saved_url = static_files_manager.save_static_file(video_bytes, filename, ExistingFilePolicy.CREATE_NEW)
+            saved = self._output_file.build_file()
+            saved.write_bytes(video_bytes)
 
             # Create VideoUrlArtifact from the saved URL
-            video_artifact = VideoUrlArtifact(saved_url)
-            logger.info(f"Saved video to static storage as {filename}. URL: {saved_url}")
+            video_artifact = VideoUrlArtifact(saved.location)
+            logger.info(f"Saved video to project storage. URL: {saved.location}")
             logger.info(f"Video ID: {actual_video_id}")  # Added logging for actual_video_id
             return video_artifact, actual_video_id
 

--- a/kling/kling_v3_multi_shot.py
+++ b/kling/kling_v3_multi_shot.py
@@ -13,8 +13,8 @@ from griptape_nodes.traits.widget import Widget
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, ParameterGroup
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
 from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.retained_mode.griptape_nodes import logger, GriptapeNodes
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 
 SERVICE = "Kling"
 API_KEY_ENV_VAR = "KLING_ACCESS_KEY"
@@ -51,6 +51,8 @@ class KlingV3MultiShot(ControlNode):
         if metadata:
             node_metadata.update(metadata)
         super().__init__(name=name, metadata=node_metadata, **kwargs)
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="kling_video.mp4")
+        self._output_file.add_parameter()
 
         # Image Inputs
         with ParameterGroup(name="Image Inputs") as image_group:
@@ -360,7 +362,7 @@ class KlingV3MultiShot(ControlNode):
         if not video_url:
             raise RuntimeError("Video generation timed out — no video URL received.")
 
-        # Download and save to static storage
+        # Download and save to project storage
         try:
             download_response = requests.get(video_url, timeout=60)
             download_response.raise_for_status()
@@ -368,13 +370,11 @@ class KlingV3MultiShot(ControlNode):
         except requests.exceptions.RequestException as e:
             raise RuntimeError(f"Failed to download generated video: {e}") from e
 
-        timestamp = int(time.time() * 1000)
-        filename = f"kling_v3_multi_shot_{timestamp}.mp4"
-        static_files_manager = GriptapeNodes.StaticFilesManager()
-        saved_url = static_files_manager.save_static_file(video_bytes, filename, ExistingFilePolicy.CREATE_NEW)
+        saved = self._output_file.build_file()
+        saved.write_bytes(video_bytes)
 
-        video_artifact = VideoUrlArtifact(saved_url)
-        logger.info(f"Saved multi-shot video as {filename}. URL: {saved_url}")
+        video_artifact = VideoUrlArtifact(saved.location)
+        logger.info(f"Saved multi-shot video to project storage. URL: {saved.location}")
 
         self.publish_update_to_parameter("video_url", video_artifact)
 

--- a/kling/lip_sync.py
+++ b/kling/lip_sync.py
@@ -8,8 +8,8 @@ from griptape_nodes.traits.options import Options
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, ParameterGroup
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.retained_mode.griptape_nodes import logger, GriptapeNodes
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.traits.file_system_picker import FileSystemPicker
 
@@ -42,6 +42,8 @@ def encode_jwt_token(ak: str, sk: str) -> str:
 class KlingAI_LipSync(ControlNode):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="kling_video.mp4")
+        self._output_file.add_parameter()
         self.category = "AI/Kling"
         self.description = "Creates lip-sync videos by synchronizing speech to video using Kling AI. Supports both Kling AI generated videos (via video ID) and uploaded videos (via video URL)."
 
@@ -557,15 +559,14 @@ class KlingAI_LipSync(ControlNode):
                         actual_video_id = result["data"]["task_result"]["videos"][0]["id"]
                         logger.info(f"Kling lip-sync succeeded: {video_url}")
 
-                        # Download the generated video and save to static storage
+                        # Download the generated video and save to project storage
                         video_bytes = File(video_url).read_bytes()
 
-                        filename = f"kling_lip_sync_{int(time.time())}.mp4"
-                        static_files_manager = GriptapeNodes.StaticFilesManager()
-                        saved_url = static_files_manager.save_static_file(video_bytes, filename, ExistingFilePolicy.CREATE_NEW)
+                        saved = self._output_file.build_file()
+                        saved.write_bytes(video_bytes)
 
                         # Create artifact and publish outputs
-                        video_artifact = VideoUrlArtifact(url=saved_url, name=filename)
+                        video_artifact = VideoUrlArtifact(url=saved.location, name=saved.location)
                         self.publish_update_to_parameter("lip_sync_video_url", video_artifact)
                         if actual_video_id:
                             self.publish_update_to_parameter("task_id", actual_video_id)

--- a/kling/motion_control.py
+++ b/kling/motion_control.py
@@ -10,8 +10,8 @@ from griptape_nodes.exe_types.node_types import SuccessFailureNode
 from griptape_nodes.exe_types.param_types.parameter_bool import ParameterBool
 from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.files.file import File, FileLoadError
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.traits.options import Options
 
@@ -45,6 +45,8 @@ class KlingAI_MotionControl(SuccessFailureNode):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="kling_video.mp4")
+        self._output_file.add_parameter()
         self.category = "AI/Kling"
         self.description = "Generates a video using Kling Motion Control (image + motion reference)."
 
@@ -429,25 +431,24 @@ class KlingAI_MotionControl(SuccessFailureNode):
             )
             return
 
-        filename = f"kling_motion_control_{task_id}.mp4"
-        static_files_manager = GriptapeNodes.StaticFilesManager()
         try:
-            saved_url = static_files_manager.save_static_file(video_bytes, filename, ExistingFilePolicy.CREATE_NEW)
+            saved = self._output_file.build_file()
+            saved.write_bytes(video_bytes)
         except (OSError, PermissionError) as exc:
-            logger.warning("%s failed to save to static storage: %s", self.name, exc)
+            logger.warning("%s failed to save to project storage: %s", self.name, exc)
             self.parameter_output_values["video_url"] = VideoUrlArtifact(download_url)
             self._set_status_results(
                 was_successful=True,
                 result_details=(
-                    "Video generated successfully. Using provider URL (could not save to static storage)."
+                    "Video generated successfully. Using provider URL (could not save to project storage)."
                 ),
             )
             return
 
-        self.parameter_output_values["video_url"] = VideoUrlArtifact(saved_url)
+        self.parameter_output_values["video_url"] = VideoUrlArtifact(saved.location)
         self._set_status_results(
             was_successful=True,
-            result_details=f"Video generated successfully and saved as {filename}.",
+            result_details=f"Video generated successfully and saved as {saved.location}.",
         )
 
     def _handle_polling_timeout(self) -> None:

--- a/kling/text_to_video.py
+++ b/kling/text_to_video.py
@@ -10,8 +10,8 @@ from griptape_nodes.traits.options import Options
 from griptape_nodes.traits.slider import Slider
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, ParameterGroup
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.retained_mode.griptape_nodes import logger, GriptapeNodes
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.files.file import File, FileLoadError
 
 
@@ -37,6 +37,8 @@ def encode_jwt_token(ak: str, sk: str) -> str:
 class KlingAI_TextToVideo(ControlNode):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="kling_video.mp4")
+        self._output_file.add_parameter()
 
         self.add_parameter(
             Parameter(
@@ -486,17 +488,15 @@ class KlingAI_TextToVideo(ControlNode):
             if not video_url:
                 raise RuntimeError(f"Video generation timed out after {max_retries * 5 / 60:.1f} minutes. Task may still be processing.")
 
-            # Download the generated video and save to static storage
+            # Download the generated video and save to project storage
             video_bytes = File(video_url).read_bytes()
 
-            timestamp = int(time.time() * 1000)
-            filename = f"kling_text_to_video_{timestamp}_{job_index}.mp4"
-            static_files_manager = GriptapeNodes.StaticFilesManager()
-            saved_url = static_files_manager.save_static_file(video_bytes, filename, ExistingFilePolicy.CREATE_NEW)
+            saved = self._output_file.build_file()
+            saved.write_bytes(video_bytes)
 
             # Create VideoUrlArtifact from the saved URL
-            artifact = VideoUrlArtifact(saved_url)
-            logger.info(f"Saved video to static storage as {filename}. URL: {saved_url}")
+            artifact = VideoUrlArtifact(saved.location)
+            logger.info(f"Saved video to project storage. URL: {saved.location}")
             logger.info(f"Video ID: {actual_video_id}")
             return artifact, actual_video_id
 

--- a/kling/video_extension.py
+++ b/kling/video_extension.py
@@ -7,8 +7,8 @@ from griptape_nodes.traits.options import Options
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, ParameterGroup
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.retained_mode.griptape_nodes import logger, GriptapeNodes
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.files.file import File, FileLoadError
 
 SERVICE = "Kling"
@@ -39,6 +39,8 @@ def encode_jwt_token(ak: str, sk: str) -> str:
 class KlingAI_VideoExtension(ControlNode):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="kling_video.mp4")
+        self._output_file.add_parameter()
         self.category = "AI/Kling"
         self.description = "Extends existing videos by 4-5 seconds using Kling AI (V1.5 only). Max total: 3 minutes."
 
@@ -215,15 +217,14 @@ class KlingAI_VideoExtension(ControlNode):
                         actual_video_id = result["data"]["task_result"]["videos"][0]["id"]
                         logger.info(f"Kling video extension succeeded: {video_url}")
                         
-                        # Download the generated video and save to static storage
+                        # Download the generated video and save to project storage
                         video_bytes = File(video_url).read_bytes()
 
-                        filename = f"kling_video_extension_{int(time.time())}.mp4"
-                        static_files_manager = GriptapeNodes.StaticFilesManager()
-                        saved_url = static_files_manager.save_static_file(video_bytes, filename, ExistingFilePolicy.CREATE_NEW)
+                        saved = self._output_file.build_file()
+                        saved.write_bytes(video_bytes)
 
                         # Create artifact and publish outputs
-                        video_artifact = VideoUrlArtifact(url=saved_url, name=filename)
+                        video_artifact = VideoUrlArtifact(url=saved.location, name=saved.location)
                         self.publish_update_to_parameter("extended_video_url", video_artifact)
                         if actual_video_id:
                             # Publish to correct parameter name declared for this node


### PR DESCRIPTION
Closes #20

Replace `StaticFilesManager.save_static_file()` with `ProjectFileParameter` for project-aware file saving.

In each of the six node files (`lip_sync.py`, `text_to_video.py`, `image_to_video.py`, `video_extension.py`, `kling_v3_multi_shot.py`, `motion_control.py`), the following changes were made:

- Added `from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter`
- Removed the `ExistingFilePolicy` import (no longer needed)
- Added `self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="kling_video.mp4")` and `self._output_file.add_parameter()` in `__init__`
- Replaced `GriptapeNodes.StaticFilesManager().save_static_file(video_bytes, filename, ExistingFilePolicy.CREATE_NEW)` with `self._output_file.build_file()` + `.write_bytes(video_bytes)`, using `saved.location` for the resulting URL