### PR TITLE
Fix: Use ParameterImage for image inputs to prevent auto-conversion

### DIFF
--- a/kling/image_to_video.py
+++ b/kling/image_to_video.py
@@ -602,8 +602,8 @@ class KlingAI_ImageToVideo(ControlNode):
             # Download the generated video and save to project storage
             video_bytes = File(video_url).read_bytes()
 
-            saved = self._output_file.build_file()
-            saved.write_bytes(video_bytes)
+            dest = self._output_file.build_file()
+            saved = dest.write_bytes(video_bytes)
 
             # Create VideoUrlArtifact from the saved URL
             video_artifact = VideoUrlArtifact(saved.location)

--- a/kling/image_to_video.py
+++ b/kling/image_to_video.py
@@ -9,6 +9,7 @@ from griptape.artifacts import ImageArtifact, ImageUrlArtifact, VideoUrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
+from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
 from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.traits.options import Options
@@ -69,20 +70,16 @@ class KlingAI_ImageToVideo(ControlNode):
 
         # Image Inputs Group
         with ParameterGroup(name="Image Inputs") as image_group:
-            Parameter(
+            ParameterImage(
                 name="image",
-                input_types=["ImageArtifact", "ImageUrlArtifact", "str"],
-                type="ImageArtifact",
                 tooltip="Reference Image (start frame) - required. Input ImageArtifact, ImageUrlArtifact, direct URL string, or Base64 string.",
-                allowed_modes={ParameterMode.INPUT},
+                allow_output=False,
                 ui_options={"display_name": "Start Frame"},
             )
-            Parameter(
+            ParameterImage(
                 name="image_tail",
-                input_types=["ImageArtifact", "ImageUrlArtifact", "str"],
-                type="ImageArtifact",
                 tooltip="Tail/End Frame image (optional). Supported on kling-v2-1 with pro mode (5s/10s). Accepts ImageArtifact, ImageUrlArtifact, URL, or Base64.",
-                allowed_modes={ParameterMode.INPUT},
+                allow_output=False,
                 ui_options={"display_name": "Tail Frame"},
             )
         self.add_node_element(image_group)
@@ -190,13 +187,10 @@ class KlingAI_ImageToVideo(ControlNode):
 
         # Masks Group
         with ParameterGroup(name="Masks") as masks_group:
-            Parameter(
+            ParameterImage(
                 name="static_mask",
-                input_types=["ImageArtifact", "ImageUrlArtifact", "str"],
-                type="ImageArtifact",
-                default_value=None,
                 tooltip="Static Brush Application Area. Input ImageArtifact, ImageUrlArtifact, direct URL, or Base64 string.",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                allow_output=False,
             )
             Parameter(
                 name="dynamic_masks",

--- a/kling/kling_v3_multi_shot.py
+++ b/kling/kling_v3_multi_shot.py
@@ -371,8 +371,8 @@ class KlingV3MultiShot(ControlNode):
         except requests.exceptions.RequestException as e:
             raise RuntimeError(f"Failed to download generated video: {e}") from e
 
-        saved = self._output_file.build_file()
-        saved.write_bytes(video_bytes)
+        dest = self._output_file.build_file()
+        saved = dest.write_bytes(video_bytes)
 
         video_artifact = VideoUrlArtifact(saved.location)
         logger.info(f"Saved multi-shot video to project storage. URL: {saved.location}")

--- a/kling/lip_sync.py
+++ b/kling/lip_sync.py
@@ -561,8 +561,8 @@ class KlingAI_LipSync(ControlNode):
                         # Download the generated video and save to project storage
                         video_bytes = File(video_url).read_bytes()
 
-                        saved = self._output_file.build_file()
-                        saved.write_bytes(video_bytes)
+                        dest = self._output_file.build_file()
+                        saved = dest.write_bytes(video_bytes)
 
                         # Create artifact and publish outputs
                         video_artifact = VideoUrlArtifact(url=saved.location, name=saved.location)

--- a/kling/motion_control.py
+++ b/kling/motion_control.py
@@ -431,8 +431,8 @@ class KlingAI_MotionControl(SuccessFailureNode):
             return
 
         try:
-            saved = self._output_file.build_file()
-            saved.write_bytes(video_bytes)
+            dest = self._output_file.build_file()
+            saved = dest.write_bytes(video_bytes)
         except (OSError, PermissionError) as exc:
             logger.warning("%s failed to save to project storage: %s", self.name, exc)
             self.parameter_output_values["video_url"] = VideoUrlArtifact(download_url)

--- a/kling/motion_control.py
+++ b/kling/motion_control.py
@@ -10,6 +10,7 @@ from griptape_nodes.exe_types.node_types import SuccessFailureNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_bool import ParameterBool
 from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
+from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
@@ -66,12 +67,10 @@ class KlingAI_MotionControl(SuccessFailureNode):
 
         # Image Input Group
         with ParameterGroup(name="Image Input") as image_group:
-            Parameter(
+            ParameterImage(
                 name="reference_image",
-                input_types=["ImageArtifact", "ImageUrlArtifact"],
-                type="ImageUrlArtifact",
                 tooltip="Reference image with character (required). Supports .jpg/.jpeg/.png, max 10MB.",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                allow_output=False,
             )
         self.add_node_element(image_group)
 

--- a/kling/text_to_video.py
+++ b/kling/text_to_video.py
@@ -512,8 +512,8 @@ class KlingAI_TextToVideo(ControlNode):
             # Download the generated video and save to project storage
             video_bytes = File(video_url).read_bytes()
 
-            saved = self._output_file.build_file()
-            saved.write_bytes(video_bytes)
+            dest = self._output_file.build_file()
+            saved = dest.write_bytes(video_bytes)
 
             # Create VideoUrlArtifact from the saved URL
             artifact = VideoUrlArtifact(saved.location)

--- a/kling/video_extension.py
+++ b/kling/video_extension.py
@@ -222,8 +222,8 @@ class KlingAI_VideoExtension(ControlNode):
                         # Download the generated video and save to project storage
                         video_bytes = File(video_url).read_bytes()
 
-                        saved = self._output_file.build_file()
-                        saved.write_bytes(video_bytes)
+                        dest = self._output_file.build_file()
+                        saved = dest.write_bytes(video_bytes)
 
                         # Create artifact and publish outputs
                         video_artifact = VideoUrlArtifact(url=saved.location, name=saved.location)


### PR DESCRIPTION
## Problems Fixed

### 1. LoadImage Auto-Conversion Error
When passing localhost URLs as strings from Display Text nodes to image inputs, the framework was auto-creating LoadImage nodes that would fail with:
```
ERROR LoadImage 'pasted-image-png-*': Failed to load image from path parameter
```

This happened because image parameters had `type="ImageArtifact"`, which triggered automatic type conversion from strings to ImageArtifact via an intermediate LoadImage node.

### 2. File Save Macro Resolution Error
When saving generated videos, all nodes failed with:
```
ERROR Attempted to resolve macro path. Failed because missing required variables: file_extension, file_name_base
```

This happened because `write_bytes()` return value wasn't being captured. The macro variables are set by the saved file object returned from `write_bytes()`, not by `build_file()`.

## Solutions

### Fix 1: Use ParameterImage for Image Inputs
Replace generic `Parameter` with `ParameterImage` for all image inputs. `ParameterImage` is the recommended approach per [Griptape Nodes documentation](https://raw.githubusercontent.com/griptape-ai/griptape-nodes/main/docs/developing_nodes/comprehensive_guide.md) and prevents automatic type conversion while still accepting all artifact types.

**Files updated:**
- `image_to_video.py`: Updated `image`, `image_tail`, and `static_mask` parameters
- `motion_control.py`: Updated `reference_image` parameter

### Fix 2: Capture write_bytes Return Value
Match the pattern used in standard library nodes (e.g., Flux). Capture the return value from `write_bytes()` which contains the properly resolved file location.

**Before:**
```python
saved = self._output_file.build_file()
saved.write_bytes(video_bytes)  # ❌ Not capturing return
artifact = VideoUrlArtifact(saved.location)
```

**After:**
```python
dest = self._output_file.build_file()
saved = dest.write_bytes(video_bytes)  # ✅ Capture saved file
artifact = VideoUrlArtifact(saved.location)
```

**Files updated:**
- `image_to_video.py`
- `text_to_video.py`
- `kling_v3_multi_shot.py`
- `motion_control.py`
- `lip_sync.py`
- `video_extension.py`

## Testing

✅ Tested Display Image → Kling Image-to-Video flow with localhost URLs
✅ Verified file saving works correctly
✅ Verified existing `_get_image_api_data_from_input()` methods handle all artifact types correctly
✅ ParameterImage pattern already used successfully in `kling_v3_multi_shot.py`
✅ write_bytes pattern matches Flux and other working nodes in standard library

---

@sshlife Ready for review